### PR TITLE
Use heuristics to define `time_t` instead of importing from system headers

### DIFF
--- a/ffi_generator.py
+++ b/ffi_generator.py
@@ -34,6 +34,49 @@ def validate_source_file(parser: ArgumentParser, entry: str) -> None | Path:
     parser.error(f"'{path}' does not exist or is not a valid source file.")
     return None
 
+def compute_time_t_definition() -> None:
+    """Use heuristics to define the `time_t` type"""
+    import ctypes
+    import platform
+
+    type_map = {
+        "c": "char",
+        "b": "signed char",
+        "B": "unsigned char",
+        "h": "short",
+        "H": "unsigned short",
+        "i": "int",
+        "I": "unsigned int",
+        "l": "long",
+        "L": "unsigned long",
+        "q": "long long",
+        "Q": "unsigned long long",
+        "n": "ssize_t",
+        "N": "size_t",
+        "f": "float",
+        "d": "double",
+    }
+
+    if hasattr(ctypes, "c_time_t"):
+        # c_time_c was added in Python 3.12
+        time_t = ctypes.c_time_t
+    # If c_time_t does not exist make an educated guess.
+    # Based on: https://stackoverflow.com/a/75904657
+    elif platform.system() == 'Windows':
+        # Assume 64-bit time_t on Windows
+        time_t = ctypes.c_int64
+    elif ctypes.sizeof(ctypes.c_void_p) == ctypes.sizeof(ctypes.c_int64):
+        # 64-bit platform of any kind - assume 64-bit time_t
+        time_t = ctypes.c_int64
+    else:
+        # assume some kind of 32-bit platform
+        time_t = ctypes.c_int32
+
+    if time_t._type_ not in type_map:
+        raise ValueError(f"Unexpected 'time_t' type: {time_t._type_}")
+    time_t_type = type_map[time_t._type_]
+
+    return f"typedef {time_t_type} time_t;"
 
 if __name__ == "__main__":
     argparser = ArgumentParser(
@@ -55,10 +98,26 @@ if __name__ == "__main__":
         required=True,
         help="The Pyext module header.",
     )
+    argparser.add_argument(
+        "--define-time-t",
+        action='store_true',
+        default=False,
+        required=False,
+        help="Use heuristics to define the `time_t` type. This type is not "
+        "guaranteed in the C specification and therefore this is definition "
+        "is best-effort. If this flag is not provided, 'time_t' must be defined "
+        "in one of the provided preprocessed header files.",
+    )
 
     args = argparser.parse_args()
 
     ffibuilder = cffi.FFI()
+
+    if args.define_time_t:
+        print("Using heuristics to define the 'time_t' type...")
+        time_t_def = compute_time_t_definition()
+        print(f"Defining 'time_t' as: '{time_t_def}'")
+        ffibuilder.cdef(time_t_def)
 
     for header in args.headers:
         ffibuilder.cdef(header.read_text())

--- a/meson.build
+++ b/meson.build
@@ -89,10 +89,6 @@ header_pp_config = {
         'source_header': librsync_py_h.full_path(),
         'clean_script_args': [
             '--header-allowlist',
-                # System headers
-                'time_t.h',
-                'types.h',
-                'stdbool.h',
                 # librsync headers
                 'librsync.h',
                 'sumset.h',
@@ -166,6 +162,7 @@ librsync_py_c = configure_file(
     command: [
         python,
         ffi_generator_script,
+        '--define-time-t',
         '--module-name',
         librsync_py_pyext_name,
         '--module-header',


### PR DESCRIPTION
Since `time_t` definition is not guaranteed in the C specification, CFFI needs to be told what it is.

However, each platform defines it in different headers in in different ways. This makes it very hard to import the definition from a system header (in a platform independent way) without also importing a bunch other unneeded definitions, which break `pycparser` (used by CFFI). 

The currrent solution to this problem was to just delete the unneeded header noise from the preprocessed system headers using regex expressios and header/line allowlists. However, this is very flimsy and easily breaks on different platforms.

This PR changes the behaviour so that instead of trying to parse out the `time_t` definition from system headers, it is computed during the FFI generation (see `ffi_generator.py`).  For Python 3.12+ this is relatively easy, since `ctypes.c_time_t` can be used to determine the correct C type. For Python 3.11 and below however, no such definition exists, thus the definition generation is based on heuristics instead.